### PR TITLE
Change Mac OS X to macOS

### DIFF
--- a/en/installation.rst
+++ b/en/installation.rst
@@ -63,7 +63,7 @@ Installing Composer
 CakePHP uses `Composer <http://getcomposer.org>`_, a dependency management tool,
 as the officially supported method for installation.
 
-- Installing Composer on Linux and Mac OS X
+- Installing Composer on Linux and macOS
 
   #. Run the installer script as described in the
      `official Composer documentation <https://getcomposer.org/download/>`_
@@ -355,7 +355,7 @@ further information.
            Allow from all
        </Directory>
 
-   On Mac OSX, another solution is to use the tool
+   On macOS, another solution is to use the tool
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_ to make a Virtual
    Host to point to your folder.
 

--- a/es/installation.rst
+++ b/es/installation.rst
@@ -331,7 +331,7 @@ obtener información.
            Allow from all
        </Directory>
 
-   En Mac OSX, otra solución es usar la herramienta
+   En macOS, otra solución es usar la herramienta
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_
    para crear servidores virtuales y apuntarlos a tu carpeta.
 

--- a/fr/installation.rst
+++ b/fr/installation.rst
@@ -65,7 +65,7 @@ Installer Composer
 CakePHP utilise `Composer <http://getcomposer.org>`_, un outil de gestion de
 dépendances comme méthode officielle supportée pour l'installation.
 
-- Installer Composer sur Linux et Mac OS X
+- Installer Composer sur Linux et macOS
 
   #. Exécutez le script d'installation comme décrit dans la
      `documentation officielle de Composer <https://getcomposer.org/download/>`_
@@ -379,7 +379,7 @@ http://wiki.apache.org/httpd/DistrosDefaultLayout pour plus d'informations.
            Allow from all
        </Directory>
 
-   Si vous êtes sur Mac OSX, une autre solution est d'utiliser l'outil
+   Si vous êtes sur macOS, une autre solution est d'utiliser l'outil
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_ pour faire un Hôte
    Virtuel pour pointer vers votre dossier.
 

--- a/ja/installation.rst
+++ b/ja/installation.rst
@@ -61,7 +61,7 @@ Composer のインストール
 CakePHP の公式のインストール方法として、依存性管理ツール
 `Composer <http://getcomposer.org>`_ を使用します。
 
-- Linux や Mac OS X に Composer をインストール
+- Linux や macOS に Composer をインストール
 
   #. `公式の Composer ドキュメント <https://getcomposer.org/download/>`_ に書かれた
      インストーラスクリプトを実行し、Composer をインストールするために指示に従ってください。
@@ -350,7 +350,7 @@ CakePHP は、展開した状態では mod_rewrite を使用するようにな�
            Allow from all
        </Directory>
 
-   Mac OSX上での別解は、仮想ホストをフォルダに向けさせるのに、
+   macOS上での別解は、仮想ホストをフォルダに向けさせるのに、
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_
    ツールを使うことが挙げられます。
 

--- a/pt/installation.rst
+++ b/pt/installation.rst
@@ -306,7 +306,7 @@ para maiores informações.
            Allow from all
        </Directory>
 
-   No Mac OSX, outra solução é usar a ferramenta
+   No macOS, outra solução é usar a ferramenta
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_
    para fazer um Virtual Host apontar para o seu diretório.
 

--- a/tr/installation.rst
+++ b/tr/installation.rst
@@ -283,7 +283,7 @@ further information.
            Allow from all
        </Directory>
 
-   On Mac OSX, another solution is to use the tool
+   On macOS, another solution is to use the tool
    `virtualhostx <http://clickontyler.com/virtualhostx/>`_
    to make a Virtual Host to point to your folder.
 


### PR DESCRIPTION
Apple recently changed the name of his operating system. It is officially named macOS. https://www.apple.com/macos/sierra/